### PR TITLE
Allow full windows to be split with mode enabled.

### DIFF
--- a/visual-fill-column.el
+++ b/visual-fill-column.el
@@ -80,7 +80,8 @@ this option is set to a value, it is used instead."
 (advice-add 'split-window
     :around #'visual-fill-column--disable-on-split-window)
 
-(defun visual-fill-column--disable-on-split-window (fn window &rest args)
+(defun visual-fill-column--disable-on-split-window (fn &optional window
+                                                    &rest args)
   "Undo the effects of `visual-fill-column-mode' for splitting window."
   (if (and (or (not window) (window-live-p window))
            (buffer-local-value 'visual-fill-column-mode

--- a/visual-fill-column.el
+++ b/visual-fill-column.el
@@ -77,6 +77,23 @@ this option is set to a value, it is used instead."
   :require 'visual-fill-column-mode
   :group 'visual-fill-column)
 
+(advice-add 'split-window
+    :around #'visual-fill-column--disable-on-split-window)
+
+(defun visual-fill-column--disable-on-split-window (fn window &rest args)
+  "Undo the effects of `visual-fill-column-mode' for splitting window."
+  (if (and (or (not window) (window-live-p window))
+           (buffer-local-value 'visual-fill-column-mode
+                               (window-buffer (or window (selected-window)))))
+    (let ((inhibit-redisplay t))
+      (set-window-fringes (or window (selected-window)) nil)
+      (set-window-margins (or window (selected-window)) 0 0)
+      (unwind-protect (apply fn window args)
+        (save-selected-window
+          (when window (select-window window 'norecord))
+          (visual-fill-column--adjust-window))))
+    (apply fn window args)))
+
 (defun turn-on-visual-fill-column-mode ()
   "Turn on `visual-fill-column-mode'.
 Note that `visual-fill-column-mode' is only turned on in buffers


### PR DESCRIPTION
Under the effect of this mode window size is reduced to the value of `visual-fill-column-width`, even though for splitting purposes it will stay the same. 
This patch attempts to address this issue by introducing around-advice to `split-window` which is involved in majority of methods affected by described behavior.
For the lack of other options to achieve same result, advice is global but will not alter behavior for windows displaying buffers with `visual-fill-column-mode` disabled.