### PR TITLE
Use package name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Installation ##
 
-Install `visual-fill-column-mode` via [Melpa](http://melpa.org), or put `visual-fill-column-mode.el` in your load path, (optionally) byte-compile it, and add `(require ’visual-fill-column)` to your `init.el`.
+Install `visual-fill-column` via [Melpa](http://melpa.org), or put `visual-fill-column-mode.el` in your load path, (optionally) byte-compile it, and add `(require ’visual-fill-column)` to your `init.el`.
 
 
 ## Usage ##


### PR DESCRIPTION
Previously the name of the mode was used instead of the package in the
installation section.