### PR TITLE
Fix window configurations not getting restored due to broken split-window call

### DIFF
--- a/visual-fill-column.el
+++ b/visual-fill-column.el
@@ -135,8 +135,13 @@ that actually visit a file."
 
 (defun visual-fill-column-split-window (&optional window size side pixelwise)
   "Split WINDOW, unsetting its margins first.
-SIZE, SIDE, and PIXELWISE are passed on to `split-window'.  This
-function is for use in the window parameter `split-window'."
+SIZE and SIDE are passed on to `split-window'. This
+function is for use in the equally named window parameter
+`split-window'.
+ As of Emacs 27.1, PIXELWISE cannot be passed through
+directly and defaults to `nil', which may create problems when
+restoring a windows state. For troubleshooting see:
+https://github.com/joostkremers/visual-fill-column/pull/47"
   (let ((horizontal (memq side '(t left right)))
 	margins new)
     (when horizontal


### PR DESCRIPTION
`visual-fill-column-split-window` was added as a window parameter to [make splitting possible with wide margins](https://lists.gnu.org/archive/html/emacs-devel/2016-01/msg01158.html). 

It gets called by `split-window` with 3 args

```emacs-lisp
    (throw 'done (funcall function window size side))
    ;; Head:     86d8d76aa3 ; lisp/ldefs-boot.el: Update.
    ;; Tag:      emacs-27.1
    ;; emacs/lisp/window.el
```

but has an excess arg in its signature that gets passed back to `split-window` as `nil`

```emacs-lisp
    (defun visual-fill-column-split-window (&optional window size side pixelwise)
      ...
      (setq new (split-window window size side pixelwise)) ;; pixelwise => nil
```
Thus, window sizes are not calculated correctly and &ldquo;Window too small to split&rdquo; errors occur that block window configurations from getting restored with `window-state-put`. It also messes with the window dimensions around the split-window call. The problem is masked by a `(condition-case nil... (error nil))`.
This affects switching doom emacs workspaces / `persp-mode` perspectives when the selected window has `visual-fill-column mode` turned on.

Fixes:
https://github.com/Bad-ptr/persp-mode.el/issues/114 
https://github.com/Bad-ptr/persp-mode.el/issues/110
https://github.com/joostkremers/writeroom-mode/issues/54